### PR TITLE
fix: set proxy server templates to listen to defined public port

### DIFF
--- a/templates/etc/apache2/sites-enabled/template.conf
+++ b/templates/etc/apache2/sites-enabled/template.conf
@@ -1,9 +1,9 @@
 {{ ansible_managed | comment }}
 
 {% for ip in ansible_all_ipv4_addresses %}
-Listen {{ ip }}:{{ item.port }}
+Listen {{ ip }}:{{ item.port_public }}
 
-<VirtualHost {{ ip }}:{{ item.port }}>
+<VirtualHost {{ ip }}:{{ item.port_public }}>
     ProxyPreserveHost On
 
     <Location "/">

--- a/templates/etc/nginx/sites-enabled/template.conf
+++ b/templates/etc/nginx/sites-enabled/template.conf
@@ -2,7 +2,7 @@
 
 server {
     {% for ip in ansible_all_ipv4_addresses %}
-    listen {{ ip }}:{{ item.port }}{% if nginx_prometheus_tls_certificate_path is defined %} ssl http2{% endif %};
+    listen {{ ip }}:{{ item.port_public }}{% if nginx_prometheus_tls_certificate_path is defined %} ssl http2{% endif %};
     {% endfor %}
 
     ## We use "_" as a dirty trick to achieve catch-all behavior. See http://nginx.org/en/docs/http/server_names.html


### PR DESCRIPTION
The `port_public` option introduced in the following commit but never used in template creation while it's really usful. https://github.com/sitewards/ansible-role-prometheus-proxy/blob/adhoc_fix_port_clash/defaults/main.yml#L12-L15

The problem with current approach is we only can configure reverse proxy to use the same port for public listening and internal reversing and it's not possible to revese trafic to a different internal port if needed.
The new approach can cover both possible cases. Reversing trafic to a different port and in case port must be the same, we still able to define the same port number in config file.